### PR TITLE
Improve handling of cleanup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Terraform vars file
 terraform.tfvars
+
+# Cleanup files
+.cleanup*

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/image.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/image.tf
@@ -24,8 +24,9 @@ EOF
 resource "local_file" "cleanup" {
   count = local.build_image ? 1 : 0
 
-  content  = "${local.image_id},${local.snapshot_id},${var.region}"
-  filename = ".cleanup"
+  content         = "${local.image_id},${local.snapshot_id},${var.region}"
+  filename        = ".cleanup-${local.image_id}"
+  file_permission = "0644"
 
   provisioner "local-exec" {
     when    = destroy


### PR DESCRIPTION
Suffixing the cleanup file name prevents it from being overwritten if the `aws-nomad-image` module is used multiple times.