### PR TITLE
fix: apt deprecation warnings cleanup

### DIFF
--- a/vagrant/horizontal-app-scaling/Vagrantfile
+++ b/vagrant/horizontal-app-scaling/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure("2") do |config|
   #   - Downloads and install Nomad and Docker
   # Only runs when the VM is created.
   config.vm.provision "deps", type: "shell", inline: <<-SHELL
+    export DEBIAN_FRONTEND=noninteractive
 
     # Install dependencies.
     apt-get update
@@ -40,11 +41,8 @@ Vagrant.configure("2") do |config|
       zip
 
     # Download and install Docker.
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) \
-      stable"
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+    echo "deb [signed-by=/usr/share/keyrings/docker.gpg arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     apt-get update
     apt-get install -y \
       docker-ce \
@@ -54,14 +52,11 @@ Vagrant.configure("2") do |config|
     usermod -aG docker vagrant
 
     # Download and install Nomad.
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
-    add-apt-repository \
-      "deb [arch=amd64] https://apt.releases.hashicorp.com \
-      $(lsb_release -cs) \
-      main"
-      apt-get update
-      apt-get install -y \
-        nomad
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp.gpg
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp.gpg arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list > /dev/null
+    apt-get update
+    apt-get install -y \
+      nomad
   SHELL
 
   # Setup demo dependencies.


### PR DESCRIPTION
apt-key has been deprecated for a while, this MR replaces the calls to it with something more modern

Signed-off-by: Bram Vogelaar <bram@attachmentgenie.com>