### PR TITLE
Fix license file conflict when installing Nomad and Consul on packer

### DIFF
--- a/cloud/infrastructure/shared/packer/scripts/setup.sh
+++ b/cloud/infrastructure/shared/packer/scripts/setup.sh
@@ -43,7 +43,7 @@ sudo ufw disable || echo "ufw not installed"
 curl -sL -o consul.zip ${CONSULDOWNLOAD}
 
 ## Install
-sudo unzip consul.zip -d /usr/local/bin
+sudo unzip -o consul.zip -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/consul
 sudo chown root:root /usr/local/bin/consul
 
@@ -57,7 +57,7 @@ sudo chmod 755 ${CONSULDIR}
 curl -sL -o nomad.zip ${NOMADDOWNLOAD}
 
 ## Install
-sudo unzip nomad.zip -d /usr/local/bin
+sudo unzip -o nomad.zip -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/nomad
 sudo chown root:root /usr/local/bin/nomad
 

--- a/cloud/shared/packer/scripts/setup.sh
+++ b/cloud/shared/packer/scripts/setup.sh
@@ -43,7 +43,7 @@ sudo ufw disable || echo "ufw not installed"
 curl -sL -o consul.zip ${CONSULDOWNLOAD}
 
 ## Install
-sudo unzip consul.zip -d /usr/local/bin
+sudo unzip -o consul.zip -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/consul
 sudo chown root:root /usr/local/bin/consul
 
@@ -57,7 +57,7 @@ sudo chmod 755 ${CONSULDIR}
 curl -sL -o nomad.zip ${NOMADDOWNLOAD}
 
 ## Install
-sudo unzip nomad.zip -d /usr/local/bin
+sudo unzip -o nomad.zip -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/nomad
 sudo chown root:root /usr/local/bin/nomad
 


### PR DESCRIPTION
fix: Add option to overwrite when unziping nomad and consul to avoid conflicts with the license file.