### PR TITLE
NMD-869 Update images for prometheus and grafana for horizontal app scaling demo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2020, 2024
+Copyright IBM Corp. 2020, 2026
 
 Mozilla Public License, version 2.0
 

--- a/cloud/aws/packer/aws-packer.pkr.hcl
+++ b/cloud/aws/packer/aws-packer.pkr.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "created_email" {}

--- a/cloud/aws/terraform/control/main.tf
+++ b/cloud/aws/terraform/control/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {

--- a/cloud/aws/terraform/control/outputs.tf
+++ b/cloud/aws/terraform/control/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "ip_addresses" {

--- a/cloud/aws/terraform/control/variables.tf
+++ b/cloud/aws/terraform/control/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "owner_name" {}

--- a/cloud/aws/terraform/modules/aws-hashistack/asg.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/asg.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_launch_template" "nomad_client" {

--- a/cloud/aws/terraform/modules/aws-hashistack/elb.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/elb.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_elb" "nomad_server" {

--- a/cloud/aws/terraform/modules/aws-hashistack/iam.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/iam.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_iam_instance_profile" "nomad_server" {

--- a/cloud/aws/terraform/modules/aws-hashistack/instances.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/instances.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_instance" "nomad_server" {

--- a/cloud/aws/terraform/modules/aws-hashistack/outputs.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "server_tag_name" {

--- a/cloud/aws/terraform/modules/aws-hashistack/sg.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/sg.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data "aws_vpc" "default" {

--- a/cloud/aws/terraform/modules/aws-hashistack/templates.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/templates.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/cloud/aws/terraform/modules/aws-hashistack/templates/user-data-client.sh
+++ b/cloud/aws/terraform/modules/aws-hashistack/templates/user-data-client.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/aws/terraform/modules/aws-hashistack/templates/user-data-server.sh
+++ b/cloud/aws/terraform/modules/aws-hashistack/templates/user-data-server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/aws/terraform/modules/aws-hashistack/variables.tf
+++ b/cloud/aws/terraform/modules/aws-hashistack/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "stack_name" {

--- a/cloud/azure/packer/azure-packer.pkr.hcl
+++ b/cloud/azure/packer/azure-packer.pkr.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "client_id" {}

--- a/cloud/azure/terraform/control/main.tf
+++ b/cloud/azure/terraform/control/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {

--- a/cloud/azure/terraform/control/outputs.tf
+++ b/cloud/azure/terraform/control/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "ip_addresses" {

--- a/cloud/azure/terraform/modules/azure-hashistack/clients.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/clients.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_linux_virtual_machine_scale_set" "clients" {

--- a/cloud/azure/terraform/modules/azure-hashistack/clients_lb.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/clients_lb.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_public_ip" "clients_lb" {

--- a/cloud/azure/terraform/modules/azure-hashistack/image.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/image.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/cloud/azure/terraform/modules/azure-hashistack/network.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/network.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_virtual_network" "primary" {

--- a/cloud/azure/terraform/modules/azure-hashistack/outputs.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "server_public_ips" {

--- a/cloud/azure/terraform/modules/azure-hashistack/rg.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/rg.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "random_pet" "server" {}

--- a/cloud/azure/terraform/modules/azure-hashistack/servers.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/servers.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_linux_virtual_machine" "servers" {

--- a/cloud/azure/terraform/modules/azure-hashistack/servers_lb.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/servers_lb.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_public_ip" "servers_lb" {

--- a/cloud/azure/terraform/modules/azure-hashistack/sg.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/sg.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "azurerm_network_security_group" "nomad_servers" {

--- a/cloud/azure/terraform/modules/azure-hashistack/ssh.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/ssh.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "tls_private_key" "main" {

--- a/cloud/azure/terraform/modules/azure-hashistack/templates.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/templates.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data "azurerm_subscription" "main" {}

--- a/cloud/azure/terraform/modules/azure-hashistack/templates/user-data-client.sh
+++ b/cloud/azure/terraform/modules/azure-hashistack/templates/user-data-client.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/azure/terraform/modules/azure-hashistack/templates/user-data-server.sh
+++ b/cloud/azure/terraform/modules/azure-hashistack/templates/user-data-server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/azure/terraform/modules/azure-hashistack/variables.tf
+++ b/cloud/azure/terraform/modules/azure-hashistack/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "location" {

--- a/cloud/demos/on-demand-batch/aws/infrastructure.tf
+++ b/cloud/demos/on-demand-batch/aws/infrastructure.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/cloud/demos/on-demand-batch/aws/main.tf
+++ b/cloud/demos/on-demand-batch/aws/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {

--- a/cloud/demos/on-demand-batch/aws/outputs.tf
+++ b/cloud/demos/on-demand-batch/aws/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "detail" {

--- a/cloud/demos/on-demand-batch/aws/variables.tf
+++ b/cloud/demos/on-demand-batch/aws/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Required variables.

--- a/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs.tf
+++ b/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data "local_file" "grafana_dashboard" {

--- a/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs/batch.nomad
+++ b/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs/batch.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "batch" {

--- a/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs/prometheus.nomad
+++ b/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs/prometheus.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "prometheus" {

--- a/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs/traefik.nomad
+++ b/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/jobs/traefik.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "traefik" {

--- a/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/variables.tf
+++ b/cloud/demos/on-demand-batch/shared/terraform/modules/nomad-jobs/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "nomad_addr" {

--- a/cloud/gcp/packer/gcp-packer.pkr.hcl
+++ b/cloud/gcp/packer/gcp-packer.pkr.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "project_id" {}

--- a/cloud/gcp/terraform/control/main.tf
+++ b/cloud/gcp/terraform/control/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Providers

--- a/cloud/gcp/terraform/control/output.tf
+++ b/cloud/gcp/terraform/control/output.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "stack_detail" {

--- a/cloud/gcp/terraform/control/variables.tf
+++ b/cloud/gcp/terraform/control/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "org_id" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/address.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/address.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "google_compute_address" "nomad_server" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/autoscaler.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/autoscaler.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data "template_file" "nomad_autoscaler_jobspec" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/firewall.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/firewall.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "google_compute_firewall" "nomad_consul_generic" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/image.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/image.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/instance_group.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/instance_group.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "google_compute_instance_template" "nomad_client" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/lb.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/lb.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "google_compute_forwarding_rule" "nomad_server" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/locals.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/locals.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/network.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/network.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "google_compute_router" "hashistack" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/output.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/output.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "google_project_id" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/project.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/project.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "google_project_service" "compute" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/provider.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/provider.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/templates/user-data-client.sh
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/templates/user-data-client.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/gcp/terraform/modules/gcp-hashistack/templates/user-data-server.sh
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/templates/user-data-server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/gcp/terraform/modules/gcp-hashistack/variables.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "project_id" {

--- a/cloud/gcp/terraform/modules/gcp-hashistack/vm.tf
+++ b/cloud/gcp/terraform/modules/gcp-hashistack/vm.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "google_compute_instance" "nomad_server" {

--- a/cloud/infrastructure/aws/packer/aws-packer.pkr.hcl
+++ b/cloud/infrastructure/aws/packer/aws-packer.pkr.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "owner_email" {}

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/asg.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/asg.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/iam.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/iam.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data "aws_iam_policy_document" "assume_role" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/outputs.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "asg_arn" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/variables.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-clients/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Required variables.

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/image.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/image.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/outputs.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "id" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/variables.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-image/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Required variables.

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/elb.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/elb.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_elb" "servers" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/outputs.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Security groups.

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/sg.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/sg.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_security_group" "agents" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/variables.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Required variables.

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/vpc.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-network/vpc.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_vpc" "main" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/iam.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/iam.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data "aws_iam_policy_document" "assume" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/instances.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/instances.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_instance" "servers" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/outputs.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 output "addresses" {

--- a/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/variables.tf
+++ b/cloud/infrastructure/aws/terraform/modules/aws-nomad-servers/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Required variables.

--- a/cloud/infrastructure/shared/packer/config/consul.hcl
+++ b/cloud/infrastructure/shared/packer/config/consul.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 advertise_addr = "IP_ADDRESS"

--- a/cloud/infrastructure/shared/packer/config/consul_client.hcl
+++ b/cloud/infrastructure/shared/packer/config/consul_client.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 advertise_addr = "IP_ADDRESS"

--- a/cloud/infrastructure/shared/packer/config/nomad.hcl
+++ b/cloud/infrastructure/shared/packer/config/nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data_dir  = "/opt/nomad/data"

--- a/cloud/infrastructure/shared/packer/config/nomad_client.hcl
+++ b/cloud/infrastructure/shared/packer/config/nomad_client.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data_dir   = "/opt/nomad/data"

--- a/cloud/infrastructure/shared/packer/scripts/client.sh
+++ b/cloud/infrastructure/shared/packer/scripts/client.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 SHAREDDIR=/ops/

--- a/cloud/infrastructure/shared/packer/scripts/net.sh
+++ b/cloud/infrastructure/shared/packer/scripts/net.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/infrastructure/shared/packer/scripts/server.sh
+++ b/cloud/infrastructure/shared/packer/scripts/server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 SHAREDDIR=/ops/

--- a/cloud/infrastructure/shared/packer/scripts/setup.sh
+++ b/cloud/infrastructure/shared/packer/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/shared/packer/config/consul.hcl
+++ b/cloud/shared/packer/config/consul.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 advertise_addr = "IP_ADDRESS"

--- a/cloud/shared/packer/config/consul_client.hcl
+++ b/cloud/shared/packer/config/consul_client.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 advertise_addr = "IP_ADDRESS"

--- a/cloud/shared/packer/config/nomad.hcl
+++ b/cloud/shared/packer/config/nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data_dir  = "/opt/nomad/data"

--- a/cloud/shared/packer/config/nomad_client.hcl
+++ b/cloud/shared/packer/config/nomad_client.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data_dir  = "/opt/nomad/data"

--- a/cloud/shared/packer/scripts/client.sh
+++ b/cloud/shared/packer/scripts/client.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 SHAREDDIR=/ops/

--- a/cloud/shared/packer/scripts/net.sh
+++ b/cloud/shared/packer/scripts/net.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/shared/packer/scripts/server.sh
+++ b/cloud/shared/packer/scripts/server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 SHAREDDIR=/ops/

--- a/cloud/shared/packer/scripts/setup.sh
+++ b/cloud/shared/packer/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/cloud/shared/terraform/modules/shared-nomad-jobs/files/prometheus.nomad
+++ b/cloud/shared/terraform/modules/shared-nomad-jobs/files/prometheus.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "prometheus" {

--- a/cloud/shared/terraform/modules/shared-nomad-jobs/files/traefik.nomad
+++ b/cloud/shared/terraform/modules/shared-nomad-jobs/files/traefik.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "traefik" {

--- a/cloud/shared/terraform/modules/shared-nomad-jobs/files/webapp.nomad
+++ b/cloud/shared/terraform/modules/shared-nomad-jobs/files/webapp.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "webapp" {

--- a/cloud/shared/terraform/modules/shared-nomad-jobs/jobs.tf
+++ b/cloud/shared/terraform/modules/shared-nomad-jobs/jobs.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 resource "null_resource" "wait_for_nomad_api" {

--- a/cloud/shared/terraform/modules/shared-nomad-jobs/variables.tf
+++ b/cloud/shared/terraform/modules/shared-nomad-jobs/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "nomad_addr" {

--- a/cloud/shared/terraform/modules/shared-nomad-jobs/version.tf
+++ b/cloud/shared/terraform/modules/shared-nomad-jobs/version.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {

--- a/vagrant/dynamic-app-sizing/files/nomad.hcl
+++ b/vagrant/dynamic-app-sizing/files/nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 // Setup some default parameters, including data_dir which is required.

--- a/vagrant/dynamic-app-sizing/jobs/das-autoscaler.nomad
+++ b/vagrant/dynamic-app-sizing/jobs/das-autoscaler.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "das-autoscaler" {

--- a/vagrant/dynamic-app-sizing/jobs/das-load-test.nomad
+++ b/vagrant/dynamic-app-sizing/jobs/das-load-test.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "das-load-test" {

--- a/vagrant/dynamic-app-sizing/jobs/example.nomad
+++ b/vagrant/dynamic-app-sizing/jobs/example.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "example" {

--- a/vagrant/dynamic-app-sizing/jobs/prometheus.nomad
+++ b/vagrant/dynamic-app-sizing/jobs/prometheus.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "prometheus" {

--- a/vagrant/horizontal-app-scaling/files/nomad.hcl
+++ b/vagrant/horizontal-app-scaling/files/nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 datacenter = "dc1"

--- a/vagrant/horizontal-app-scaling/jobs/autoscaler.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/autoscaler.nomad
@@ -18,7 +18,7 @@ job "autoscaler" {
       driver = "docker"
 
       config {
-        image   = "hashicorp/nomad-autoscaler:0.4.9"
+        image   = "hashicorp/nomad-autoscaler:0.5.0"
         command = "nomad-autoscaler"
         ports   = ["http"]
 
@@ -42,7 +42,7 @@ job "autoscaler" {
       # }
       #
       # artifact {
-      #   source      = "https://releases.hashicorp.com/nomad-autoscaler/0.4.9/nomad-autoscaler_0.4.9_linux_amd64.zip"
+      #   source      = "https://releases.hashicorp.com/nomad-autoscaler/0.5.0/nomad-autoscaler_0.5.0_linux_amd64.zip"
       #   destination = "/usr/local/bin"
       # }
 

--- a/vagrant/horizontal-app-scaling/jobs/autoscaler.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/autoscaler.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "autoscaler" {

--- a/vagrant/horizontal-app-scaling/jobs/autoscaler.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/autoscaler.nomad
@@ -18,7 +18,7 @@ job "autoscaler" {
       driver = "docker"
 
       config {
-        image   = "hashicorp/nomad-autoscaler:0.3.7"
+        image   = "hashicorp/nomad-autoscaler:0.4.9"
         command = "nomad-autoscaler"
         ports   = ["http"]
 
@@ -42,7 +42,7 @@ job "autoscaler" {
       # }
       #
       # artifact {
-      #   source      = "https://releases.hashicorp.com/nomad-autoscaler/0.3.7/nomad-autoscaler_0.3.7_linux_amd64.zip"
+      #   source      = "https://releases.hashicorp.com/nomad-autoscaler/0.4.9/nomad-autoscaler_0.4.9_linux_amd64.zip"
       #   destination = "/usr/local/bin"
       # }
 
@@ -100,7 +100,7 @@ strategy "target-value" {
       }
 
       config {
-        image = "grafana/promtail:2.6.1"
+        image = "grafana/promtail:3.5.5"
         ports = ["promtail"]
 
         args = [
@@ -119,7 +119,7 @@ positions:
   filename: /tmp/positions.yaml
 
 client:
-  url: http://{{ range $i, $s := nomadService "loki" }}{{ if eq $i 0 }}{{.Address}}:{{.Port}}{{end}}{{end}}/api/prom/push
+  url: http://{{ range $i, $s := nomadService "loki" }}{{ if eq $i 0 }}{{.Address}}:{{.Port}}{{end}}{{end}}/loki/api/v1/push
 
 scrape_configs:
 - job_name: system

--- a/vagrant/horizontal-app-scaling/jobs/grafana.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/grafana.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "grafana" {

--- a/vagrant/horizontal-app-scaling/jobs/grafana.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/grafana.nomad
@@ -94,7 +94,7 @@ EOH
 
       resources {
         cpu    = 100
-        memory = 64
+        memory = 512
       }
 
       service {

--- a/vagrant/horizontal-app-scaling/jobs/grafana.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/grafana.nomad
@@ -20,7 +20,7 @@ job "grafana" {
       driver = "docker"
 
       config {
-        image = "grafana/grafana:9.2.0"
+        image = "grafana/grafana:11.6.3"
         ports = ["grafana_ui"]
 
         volumes = [

--- a/vagrant/horizontal-app-scaling/jobs/loki.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/loki.nomad
@@ -15,7 +15,7 @@ job "loki" {
       driver = "docker"
 
       config {
-        image = "grafana/loki:2.6.1"
+        image = "grafana/loki:3.5.5"
         ports = ["loki"]
 
         args = [
@@ -33,36 +33,37 @@ job "loki" {
 auth_enabled: false
 server:
   http_listen_port: {{ env "NOMAD_PORT_loki" }}
+common:
+  ring:
+    kvstore:
+      store: inmemory
+    instance_addr: 127.0.0.1
+  replication_factor: 1
+  path_prefix: /loki
 ingester:
-  lifecycler:
-    address: 127.0.0.1
-    ring:
-      kvstore:
-        store: inmemory
-      replication_factor: 1
-    final_sleep: 0s
   chunk_idle_period: 5m
   chunk_retain_period: 30s
   wal:
     dir: /loki/wal
 schema_config:
   configs:
-  - from: 2020-05-15
-    store: boltdb
+  - from: 2024-01-01
+    store: tsdb
     object_store: filesystem
-    schema: v11
+    schema: v13
     index:
       prefix: index_
-      period: 168h
+      period: 24h
 storage_config:
-  boltdb:
-    directory: /loki/index
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
   filesystem:
     directory: /loki/chunks
 limits_config:
-  enforce_metric_name: false
   reject_old_samples: true
   reject_old_samples_max_age: 168h
+  allow_structured_metadata: false
 EOH
 
         change_mode   = "signal"

--- a/vagrant/horizontal-app-scaling/jobs/loki.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/loki.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "loki" {

--- a/vagrant/horizontal-app-scaling/jobs/prometheus.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/prometheus.nomad
@@ -15,7 +15,7 @@ job "prometheus" {
       driver = "docker"
 
       config {
-        image = "prom/prometheus:v2.38.0"
+        image = "prom/prometheus:v3.5.0"
         ports = ["prometheus_ui"]
 
         # Use `host` network so we can communicate with the Nomad

--- a/vagrant/horizontal-app-scaling/jobs/prometheus.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/prometheus.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "prometheus" {

--- a/vagrant/horizontal-app-scaling/jobs/traefik.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/traefik.nomad
@@ -41,7 +41,7 @@ job "traefik" {
     task "server" {
       driver = "docker"
       config {
-        image        = "traefik:v2.9.1"
+        image        = "traefik:v3.5.3"
         ports        = ["admin", "grafana", "prometheus", "webapp"]
         network_mode = "host"
         args = [

--- a/vagrant/horizontal-app-scaling/jobs/traefik.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/traefik.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "traefik" {

--- a/vagrant/horizontal-app-scaling/jobs/webapp.nomad
+++ b/vagrant/horizontal-app-scaling/jobs/webapp.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "webapp" {

--- a/vagrant/shared/consul.hcl
+++ b/vagrant/shared/consul.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2020, 2024
+# Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 datacenter       = "dc1"


### PR DESCRIPTION
**Note:** This PR will not completely fixed the demos, I'll raise the follow up PRs.

**Description:**

Refresh outdated container images in the Vagrant-based horizontal-app-scaling demo so it works against current releases:

- nomad-autoscaler: 0.3.7 -> 0.5.0 (image + commented artifact URL)
- prometheus:       v2.38.0 -> v3.5.0
- grafana:          9.2.0   -> 11.6.3
- loki:             2.6.1   -> 3.5.5
- promtail:         2.6.1   -> 3.5.5
- traefik:          v2.9.1  -> v3.5.3
- toxiproxy:        2.1.4   -> 2.12.0

Loki 3.x removed the boltdb index store, so migrate schema_config to v13 + tsdb and switch storage_config to tsdb_shipper. Also drop the deprecated enforce_metric_name limit.

Loki 3.x removed the legacy /api/prom/push endpoint, so update the promtail client URL to /loki/api/v1/push.

The upstream shopify/toxiproxy image on Docker Hub was abandoned. The current image (ghcr.io/shopify/toxiproxy:2.12.0) is built FROM scratch with no shell or the old /go/bin/* binary paths, so restructure the toxiproxy task into two prestart lifecycle tasks: a docker sidecar running the server, and a short-lived exec task that downloads toxiproxy-cli via artifact block and configures the proxy on startup.
