### PR TITLE
 Fix Vagrantfile provisioning for multi-arch support

### DIFF
--- a/vagrant/horizontal-app-scaling/Vagrantfile
+++ b/vagrant/horizontal-app-scaling/Vagrantfile
@@ -73,11 +73,13 @@ Vagrant.configure("2") do |config|
     # Copy across the config files.
     cp /home/vagrant/nomad-autoscaler/files/nomad.hcl /etc/nomad.d/
 
-    # On ARM64, Nomad cannot auto-detect CPU speed and reports cpu.totalcompute=0,
-    # preventing scheduling of any CPU-requesting jobs. Copy an overlay config
-    # only on aarch64 VMs; Nomad merges all .hcl files in /etc/nomad.d/.
+    # Nomad uses gopsutil to read "cpu MHz" from /proc/cpuinfo to compute
+    # cpu.totalcompute. Some hypervisors (notably VirtualBox on macOS ARM64)
+    # do not expose CPU frequency there; Nomad then reports 0 MHz and cannot
+    # schedule any CPU-requesting jobs. Guard on the missing entry directly —
+    # this is correct for all architectures and hypervisors.
     rm -f /etc/nomad.d/nomad-arm64.hcl
-    if [ "$(uname -m)" = "aarch64" ]; then
+    if ! grep -q "^cpu MHz" /proc/cpuinfo; then
       cp /home/vagrant/nomad-autoscaler/files/nomad-arm64.hcl /etc/nomad.d/
     fi
 

--- a/vagrant/horizontal-app-scaling/Vagrantfile
+++ b/vagrant/horizontal-app-scaling/Vagrantfile
@@ -41,8 +41,8 @@ Vagrant.configure("2") do |config|
       zip
 
     # Download and install Docker.
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
-    echo "deb [signed-by=/usr/share/keyrings/docker.gpg arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker.gpg
+    echo "deb [signed-by=/usr/share/keyrings/docker.gpg arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     apt-get update
     apt-get install -y \
       docker-ce \
@@ -52,8 +52,8 @@ Vagrant.configure("2") do |config|
     usermod -aG docker vagrant
 
     # Download and install Nomad.
-    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp.gpg
-    echo "deb [signed-by=/usr/share/keyrings/hashicorp.gpg arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list > /dev/null
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/hashicorp.gpg
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list > /dev/null
     apt-get update
     apt-get install -y \
       nomad
@@ -73,9 +73,17 @@ Vagrant.configure("2") do |config|
     # Copy across the config files.
     cp /home/vagrant/nomad-autoscaler/files/nomad.hcl /etc/nomad.d/
 
+    # On ARM64, Nomad cannot auto-detect CPU speed and reports cpu.totalcompute=0,
+    # preventing scheduling of any CPU-requesting jobs. Copy an overlay config
+    # only on aarch64 VMs; Nomad merges all .hcl files in /etc/nomad.d/.
+    rm -f /etc/nomad.d/nomad-arm64.hcl
+    if [ "$(uname -m)" = "aarch64" ]; then
+      cp /home/vagrant/nomad-autoscaler/files/nomad-arm64.hcl /etc/nomad.d/
+    fi
+
     # Enable and start the daemons
     sudo systemctl enable nomad
-    sudo systemctl start nomad
+    sudo systemctl restart nomad
   SHELL
 
 end

--- a/vagrant/horizontal-app-scaling/Vagrantfile
+++ b/vagrant/horizontal-app-scaling/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/jammy64"
+  config.vm.box = "bento/ubuntu-22.04"
 
   # Expose ports to the host.
   config.vm.network "forwarded_port", guest: 3000, host: 3000, host_ip: "127.0.0.1"    # Grafana

--- a/vagrant/horizontal-app-scaling/files/nomad-arm64.hcl
+++ b/vagrant/horizontal-app-scaling/files/nomad-arm64.hcl
@@ -1,9 +1,12 @@
 # Copyright IBM Corp. 2020, 2026
 # SPDX-License-Identifier: MPL-2.0
 
-# ARM64 VMs cannot auto-detect CPU speed; Nomad reports cpu.totalcompute = 0
-# without this override, which prevents scheduling of CPU-requesting jobs.
-# This file is only copied into /etc/nomad.d/ on aarch64 VMs (see Vagrantfile).
+# Nomad uses gopsutil to read "cpu MHz" from /proc/cpuinfo to compute
+# cpu.totalcompute. Some hypervisors (notably VirtualBox on macOS ARM64)
+# do not expose CPU frequency there; Nomad then reports 0 MHz and cannot
+# schedule any CPU-requesting jobs.
+# This file is only copied into /etc/nomad.d/ when /proc/cpuinfo lacks a
+# "cpu MHz" entry — see the guard in Vagrantfile.
 client {
   cpu_total_compute = 4000
 }

--- a/vagrant/horizontal-app-scaling/files/nomad-arm64.hcl
+++ b/vagrant/horizontal-app-scaling/files/nomad-arm64.hcl
@@ -1,0 +1,9 @@
+# Copyright IBM Corp. 2020, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+# ARM64 VMs cannot auto-detect CPU speed; Nomad reports cpu.totalcompute = 0
+# without this override, which prevents scheduling of CPU-requesting jobs.
+# This file is only copied into /etc/nomad.d/ on aarch64 VMs (see Vagrantfile).
+client {
+  cpu_total_compute = 4000
+}


### PR DESCRIPTION
**Problem**

The `horizontal-app-scaling` demo fails to provision on ARM64 machines (Apple Silicon + VirtualBox 7.x). VirtualBox 7.x on ARM64 runs ARM64 VMs natively and rejects the existing `ubuntu/jammy64` box (x86-only) with `VBOX_E_PLATFORM_ARCH_NOT_SUPPORTED`. Even after fixing the box, three additional provisioning bugs prevent Docker and Nomad from installing correctly on ARM64.


| File | Change | Reason |
| :--- | :--- | :--- |
| `Vagrantfile` | Box &rarr; `bento/ubuntu-22.04` | `ubuntu/jammy64` is x86-only; `bento/ubuntu-22.04` is multi-arch |
| `Vagrantfile` | Add `--batch --yes` to both `gpg --dearmor` calls | Vagrant provisioners have no TTY; without these flags gpg fails silently |
| `Vagrantfile` | `arch=amd64` &rarr; `arch=$(dpkg --print-architecture)` (Docker + HashiCorp repos) | Hardcoded `amd64` prevents ARM64 packages from being found |
| `Vagrantfile` | `systemctl start` &rarr; `systemctl restart` | `start` is a no-op on an already-running service; `restart` applies config changes on re-provision |
| `files/nomad-arm64.hcl` *(new)* | Sets `cpu_total_compute = 4000` | Nomad reports `cpu.totalcompute = 0` on ARM64 VMs, blocking all CPU-requesting job allocations. Overlay is only applied on `aarch64` (if data is missing); x86 is unchanged. |
  
  **Testing**
<img width="1466" height="717" alt="Screenshot 2026-05-22 at 2 21 06 PM" src="https://github.com/user-attachments/assets/47bf47de-84de-4c80-83f9-efbe330721ee" />

Tested on Apple Silicon (ARM64) with VirtualBox 7.x:
  - `vagrant up` provisions successfully — Docker 29.x + Nomad 2.0.1 installed
  - `cpu.totalcompute = 4000` confirmed via `nomad node status`
  - loki, prometheus, grafana, traefik, autoscaler — all healthy

**Note:** `webapp` fails with `exec format error` — this is a pre-existing issue with `hashicorp/demo-webapp-lb-guide` being amd64-only.
  