### PR TITLE
Update Packer base images to Ubuntu 22.04-Jammy (Part-1)

### DIFF
--- a/cloud/aws/packer/aws-packer.pkr.hcl
+++ b/cloud/aws/packer/aws-packer.pkr.hcl
@@ -13,7 +13,7 @@ source "amazon-ebs" "hashistack" {
   source_ami_filter {
     filters = {
       virtualization-type = "hvm"
-      name                = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
+      name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
       root-device-type    = "ebs"
     }
     owners      = ["099720109477"] # Canonical's owner ID
@@ -25,7 +25,7 @@ source "amazon-ebs" "hashistack" {
 
   tags = {
     OS_Version    = "Ubuntu"
-    Release       = "20.04"
+    Release       = "22.04"
     Architecture  = "amd64"
     Created_Email = var.created_email
     Created_Name  = var.created_name

--- a/cloud/azure/packer/azure-packer.pkr.hcl
+++ b/cloud/azure/packer/azure-packer.pkr.hcl
@@ -14,9 +14,9 @@ source "azure-arm" "hashistack" {
   }
   client_id                         = "${var.client_id}"
   client_secret                     = "${var.client_secret}"
-  image_offer                       = "UbuntuServer"
+  image_offer                       = "0001-com-ubuntu-server-jammy"
   image_publisher                   = "Canonical"
-  image_sku                         = "18.04-LTS"
+  image_sku                         = "22_04-lts"
   location                          = "${var.location}"
   managed_image_name                = "${var.image_name}"
   managed_image_resource_group_name = "${var.resource_group}"

--- a/cloud/gcp/packer/gcp-packer.pkr.hcl
+++ b/cloud/gcp/packer/gcp-packer.pkr.hcl
@@ -3,14 +3,14 @@
 
 variable "project_id" {}
 variable "image_name" { default = "hashistack" }
-variable "source_image" { default = "ubuntu-2004-focal-v20200720" }
+variable "source_image_family" { default = "ubuntu-2204-lts" }
 variable "ssh_username" { default = "ubuntu" }
 variable "zone" { default = "us-central1-a" }
 
 source "googlecompute" "hashistack" {
   image_name   = "${var.image_name}"
   project_id   = "${var.project_id}"
-  source_image = "${var.source_image}"
+  source_image_family = "${var.source_image_family}"
   ssh_username = "${var.ssh_username}"
   zone         = "${var.zone}"
 }

--- a/cloud/infrastructure/aws/packer/aws-packer.pkr.hcl
+++ b/cloud/infrastructure/aws/packer/aws-packer.pkr.hcl
@@ -20,7 +20,7 @@ source "amazon-ebs" "hashistack" {
   source_ami_filter {
     filters = {
       virtualization-type = "hvm"
-      name                = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
+      name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
       root-device-type    = "ebs"
     }
     owners      = ["099720109477"] # Canonical's owner ID
@@ -32,7 +32,7 @@ source "amazon-ebs" "hashistack" {
 
   tags = {
     OS           = "Ubuntu"
-    Release      = "20.04"
+    Release      = "22.04"
     Architecture = "amd64"
     OwnerName    = var.owner_name
     OwnerEmail   = var.owner_email


### PR DESCRIPTION
**Description:**
[
Ticket](https://hashicorp.atlassian.net/browse/NMD-1535?atlOrigin=eyJpIjoiZWM0NDViYjcwYzk3NDA1ODgxM2ZjZmNkMDM1M2UzNzgiLCJwIjoiaiJ9)

Updates the Packer source image references across all three cloud
providers to Ubuntu 22.04 LTS (Jammy Jellyfish).

 **Changes**

| Provider | Before | After |
|----------|--------|-------|
| AWS (`cloud/aws`) | `ubuntu-focal-20.04-amd64-server-*` | `ubuntu-jammy-22.04-amd64-server-*` |
| AWS (`cloud/infrastructure/aws`) | `ubuntu-focal-20.04-amd64-server-*` | `ubuntu-jammy-22.04-amd64-server-*` |
| GCP | `source_image: ubuntu-2004-focal-v20200720` | `source_image_family: ubuntu-2204-lts` |
| Azure | `UbuntuServer / 18.04-LTS` | `0001-com-ubuntu-server-jammy / 22_04-lts` |

**Testing** : I'll do testing in the later follow-up PR. 

