### PR TITLE
Update Dynamic App Sizing Vagrant demo to Ubuntu 22.04 (Part-2)

### DIFF
--- a/vagrant/dynamic-app-sizing/README.md
+++ b/vagrant/dynamic-app-sizing/README.md
@@ -2,4 +2,16 @@
 
 Instructions available at [HashiCorp Learn][learn_dynamic_app_sizing].
 
+## Prerequisites
+
+This demo requires **Nomad Enterprise** and **Nomad Autoscaler Enterprise** licenses,
+as Dynamic Application Sizing is an Enterprise-only feature.
+
+Export your Nomad Enterprise license on the host before running `vagrant up`:
+
+```shell
+export NOMAD_LICENSE=<your-nomad-enterprise-license>
+vagrant up
+```
+
 [learn_dynamic_app_sizing]: https://learn.hashicorp.com/tutorials/nomad/dynamic-application-sizing?in=nomad/autoscaler

--- a/vagrant/dynamic-app-sizing/README.md
+++ b/vagrant/dynamic-app-sizing/README.md
@@ -14,4 +14,4 @@ export NOMAD_LICENSE=<your-nomad-enterprise-license>
 vagrant up
 ```
 
-[learn_dynamic_app_sizing]: https://learn.hashicorp.com/tutorials/nomad/dynamic-application-sizing?in=nomad/autoscaler
+[learn_dynamic_app_sizing]: https://developer.hashicorp.com/nomad/tutorials/autoscaler/dynamic-application-sizing

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -51,17 +51,29 @@ Vagrant.configure("2") do |config|
     echo "deb [signed-by=/usr/share/keyrings/hashicorp.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list > /dev/null
     apt-get update
     apt-get install -y \
-      nomad \
+      nomad-enterprise \
       consul
   SHELL
 
   # Setup demo dependencies.
   #   - Create daemons for Nomad and Consul
   # Runs everytime the VM starts.
-  config.vm.provision "app:setup", type: "shell", run: "always", inline: <<-SHELL
+  config.vm.provision "app:setup", type: "shell", run: "always",
+    env: {"NOMAD_LICENSE" => ENV.fetch("NOMAD_LICENSE", "")},
+    inline: <<-SHELL
     # Copy across the config files.
     cp /home/vagrant/nomad-autoscaler-shared/consul.hcl /etc/consul.d/
     cp /home/vagrant/nomad-autoscaler/files/nomad.hcl /etc/nomad.d/
+
+    # Pass the Nomad Enterprise license to the systemd service via a drop-in,
+    # reading it from the NOMAD_LICENSE env var exported on the host before
+    # running `vagrant up`.
+    if [ -n "$NOMAD_LICENSE" ]; then
+      mkdir -p /etc/systemd/system/nomad.service.d
+      printf '[Service]\nEnvironment="NOMAD_LICENSE=%s"\n' "$NOMAD_LICENSE" \
+        > /etc/systemd/system/nomad.service.d/license.conf
+      systemctl daemon-reload
+    fi
 
     # Enable and start the daemons
     systemctl enable consul

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -78,6 +78,16 @@ Vagrant.configure("2") do |config|
       > /etc/systemd/system/nomad.service.d/license.conf
     systemctl daemon-reload
 
+    # Nomad uses gopsutil to read "cpu MHz" from /proc/cpuinfo to compute
+    # cpu.totalcompute. Some hypervisors (notably VirtualBox on macOS ARM64)
+    # do not expose CPU frequency there; Nomad then reports 0 MHz and cannot
+    # schedule any CPU-requesting jobs. Guard on the missing entry directly —
+    # this is correct for all architectures and hypervisors.
+    rm -f /etc/nomad.d/nomad-arm64.hcl
+    if ! grep -q "^cpu MHz" /proc/cpuinfo; then
+      cp /home/vagrant/nomad-autoscaler/files/nomad-arm64.hcl /etc/nomad.d/
+    fi
+
     # Enable and start the daemons
     systemctl enable consul
     systemctl restart consul

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -32,11 +32,8 @@ Vagrant.configure("2") do |config|
       apt-transport-https \
       ca-certificates \
       curl \
-      gnupg-agent \
       jq \
-      redis-server \
-      software-properties-common \
-      zip
+      software-properties-common
 
     # Download and install Docker.
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker.gpg
@@ -62,14 +59,6 @@ Vagrant.configure("2") do |config|
   #   - Create daemons for Nomad and Consul
   # Runs everytime the VM starts.
   config.vm.provision "app:setup", type: "shell", run: "always", inline: <<-SHELL
-    # Configure the Nomad and Consul daemons.
-    pushd /home/vagrant/nomad-autoscaler-shared
-    for t in consul nomad; do
-      cp ${t}.service /etc/systemd/system/
-      mkdir -p /etc/${t}.d
-    done
-    popd
-
     # Copy across the config files.
     cp /home/vagrant/nomad-autoscaler-shared/consul.hcl /etc/consul.d/
     cp /home/vagrant/nomad-autoscaler/files/nomad.hcl /etc/nomad.d/

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -26,8 +26,6 @@ Vagrant.configure("2") do |config|
   # Only runs when the VM is created.
   config.vm.provision "deps", type: "shell", inline: <<-SHELL
 
-    mkdir /tmp/downloads
-
     # Install dependencies.
     apt-get update
     apt-get install -y \
@@ -40,9 +38,6 @@ Vagrant.configure("2") do |config|
       software-properties-common \
       zip
 
-    nomad_version=1.0.3+ent
-    consul_version=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/consul | jq -r '.current_version')
-
     # Download and install Docker.
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker.gpg
     echo "deb [signed-by=/usr/share/keyrings/docker.gpg arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
@@ -54,22 +49,13 @@ Vagrant.configure("2") do |config|
     docker run hello-world
     usermod -aG docker vagrant
 
-    # Create the HashiCorp binary destination.
-    mkdir -p /opt/hashicorp/bin
-
     # Download and install Nomad and Consul.
-    pushd /tmp/downloads
-    curl --silent --show-error --remote-name-all \
-      https://releases.hashicorp.com/nomad/${nomad_version}/nomad_${nomad_version}_linux_amd64.zip \
-      https://releases.hashicorp.com/consul/${consul_version}/consul_${consul_version}_linux_amd64.zip
-    unzip nomad_${nomad_version}_linux_amd64.zip
-    unzip consul_${consul_version}_linux_amd64.zip
-    mv nomad consul /opt/hashicorp/bin
-    chmod +x /opt/hashicorp/bin/{nomad,consul}
-    ln -s /opt/hashicorp/bin/{nomad,consul} /usr/local/bin
-    popd
-
-    rm -fr /tmp/downloads
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/hashicorp.gpg
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list > /dev/null
+    apt-get update
+    apt-get install -y \
+      nomad \
+      consul
   SHELL
 
   # Setup demo dependencies.

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "bento/ubuntu-22.04"
 
   # Expose ports to the host.
   config.vm.network "forwarded_port", guest: 4646, host: 4646, host_ip: "127.0.0.1" # Nomad HTTP API/UI

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant.configure("2") do |config|
   #   - Downloads and install Nomad, Consul and Docker
   # Only runs when the VM is created.
   config.vm.provision "deps", type: "shell", inline: <<-SHELL
+    export DEBIAN_FRONTEND=noninteractive
 
     # Install dependencies.
     apt-get update

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -69,12 +69,14 @@ Vagrant.configure("2") do |config|
     # Pass the Nomad Enterprise license to the systemd service via a drop-in,
     # reading it from the NOMAD_LICENSE env var exported on the host before
     # running `vagrant up`.
-    if [ -n "$NOMAD_LICENSE" ]; then
-      mkdir -p /etc/systemd/system/nomad.service.d
-      printf '[Service]\nEnvironment="NOMAD_LICENSE=%s"\n' "$NOMAD_LICENSE" \
-        > /etc/systemd/system/nomad.service.d/license.conf
-      systemctl daemon-reload
+    if [ -z "$NOMAD_LICENSE" ]; then
+      echo "ERROR: NOMAD_LICENSE is not set. Export your Nomad Enterprise license on the host before running vagrant up."
+      exit 1
     fi
+    mkdir -p /etc/systemd/system/nomad.service.d
+    printf '[Service]\nEnvironment="NOMAD_LICENSE=%s"\n' "$NOMAD_LICENSE" \
+      > /etc/systemd/system/nomad.service.d/license.conf
+    systemctl daemon-reload
 
     # Enable and start the daemons
     systemctl enable consul

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -44,11 +44,8 @@ Vagrant.configure("2") do |config|
     consul_version=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/consul | jq -r '.current_version')
 
     # Download and install Docker.
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) \
-      stable"
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker.gpg
+    echo "deb [signed-by=/usr/share/keyrings/docker.gpg arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     apt-get update
     apt-get install -y \
       docker-ce \

--- a/vagrant/dynamic-app-sizing/Vagrantfile
+++ b/vagrant/dynamic-app-sizing/Vagrantfile
@@ -78,9 +78,9 @@ Vagrant.configure("2") do |config|
 
     # Enable and start the daemons
     systemctl enable consul
-    systemctl start consul
+    systemctl restart consul
     sudo systemctl enable nomad
-    sudo systemctl start nomad
+    sudo systemctl restart nomad
   SHELL
 
 end

--- a/vagrant/dynamic-app-sizing/files/nomad-arm64.hcl
+++ b/vagrant/dynamic-app-sizing/files/nomad-arm64.hcl
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2020, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+# Nomad uses gopsutil to read "cpu MHz" from /proc/cpuinfo to compute
+# cpu.totalcompute. Some hypervisors (notably VirtualBox on macOS ARM64)
+# do not expose CPU frequency there; Nomad then reports 0 MHz and cannot
+# schedule any CPU-requesting jobs.
+# This file is only copied into /etc/nomad.d/ when /proc/cpuinfo lacks a
+# "cpu MHz" entry — see the guard in Vagrantfile.
+client {
+  cpu_total_compute = 4000
+}


### PR DESCRIPTION
**Description:**  
[Ticket](https://hashicorp.atlassian.net/browse/NMD-1535?atlOrigin=eyJpIjoiZWM0NDViYjcwYzk3NDA1ODgxM2ZjZmNkMDM1M2UzNzgiLCJwIjoiaiJ9)

Single file changed: `vagrant/dynamic-app-sizing/Vagrantfile`

| # | Change | Detail |
|---|--------|--------|
| 1 | **Base box** | `ubuntu/focal64` → `bento/ubuntu-22.04` |
| 2 | **Docker GPG** | Replace deprecated `apt-key add` with `gpg --dearmor` keyring |
| 3 | **Nomad + Consul install** | Remove hardcoded `nomad_version=1.0.3+ent` + zip/unzip; use HashiCorp apt repo instead |
| 4 | **app:setup provisioner** | Remove manual Consul systemd setup (apt package handles it) |
| 5 | **Remove `redis-server`** | DAS demo runs Redis as a Docker container via Nomad job — system install not needed

**Testing**: E2E testing will be done in the next follow-up PR (part-3)