### PR TITLE
 Fix Packer provisioner scripts for DAS demo on Ubuntu 22.04 (Part-3)

### DIFF
--- a/cloud/infrastructure/shared/packer/scripts/client.sh
+++ b/cloud/infrastructure/shared/packer/scripts/client.sh
@@ -93,4 +93,4 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 # Set env vars for tool CLIs
 echo "export VAULT_ADDR=http://$IP_ADDRESS:8200" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc

--- a/cloud/infrastructure/shared/packer/scripts/client.sh
+++ b/cloud/infrastructure/shared/packer/scripts/client.sh
@@ -32,7 +32,7 @@ sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service
 ## Replace existing Consul binary if remote file exists
 if [[ `wget -S --spider $CONSUL_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $CONSUL_BINARY > consul.zip
-  sudo unzip -o consul.zip -d /usr/local/bin
+  sudo unzip -o consul.zip consul -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/consul
   sudo chown root:root /usr/local/bin/consul
 fi
@@ -45,7 +45,7 @@ sleep 10
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $NOMAD_BINARY > nomad.zip
-  sudo unzip -o nomad.zip -d /usr/local/bin
+  sudo unzip -o nomad.zip nomad -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/nomad
   sudo chown root:root /usr/local/bin/nomad
 fi
@@ -93,4 +93,4 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 # Set env vars for tool CLIs
 echo "export VAULT_ADDR=http://$IP_ADDRESS:8200" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:/bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc

--- a/cloud/infrastructure/shared/packer/scripts/server.sh
+++ b/cloud/infrastructure/shared/packer/scripts/server.sh
@@ -26,7 +26,7 @@ RETRY_JOIN=$3
 ## Replace existing Consul binary if remote file exists
 if [[ `wget -S --spider $CONSUL_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $CONSUL_BINARY > consul.zip
-  sudo unzip -o consul.zip -d /usr/local/bin
+  sudo unzip -o consul.zip consul -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/consul
   sudo chown root:root /usr/local/bin/consul
 fi
@@ -47,7 +47,7 @@ export CONSUL_RPC_ADDR=$IP_ADDRESS:8400
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $NOMAD_BINARY > nomad.zip
-  sudo unzip -o nomad.zip -d /usr/local/bin
+  sudo unzip -o nomad.zip nomad -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/nomad
   sudo chown root:root /usr/local/bin/nomad
 fi
@@ -83,5 +83,5 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 echo "export CONSUL_RPC_ADDR=$IP_ADDRESS:8400" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:/bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
 

--- a/cloud/infrastructure/shared/packer/scripts/server.sh
+++ b/cloud/infrastructure/shared/packer/scripts/server.sh
@@ -83,5 +83,5 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 echo "export CONSUL_RPC_ADDR=$IP_ADDRESS:8400" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
 

--- a/cloud/infrastructure/shared/packer/scripts/setup.sh
+++ b/cloud/infrastructure/shared/packer/scripts/setup.sh
@@ -75,9 +75,7 @@ sudo apt-get update
 sudo apt-get install -y docker-ce
 
 # Java
-sudo add-apt-repository -y ppa:openjdk-r/ppa
-sudo apt-get update 
-sudo apt-get install -y openjdk-8-jdk
+sudo apt-get install -y openjdk-11-jdk
 JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
 
 # CNI plugins

--- a/cloud/infrastructure/shared/packer/scripts/setup.sh
+++ b/cloud/infrastructure/shared/packer/scripts/setup.sh
@@ -43,7 +43,7 @@ sudo ufw disable || echo "ufw not installed"
 curl -sL -o consul.zip ${CONSULDOWNLOAD}
 
 ## Install
-sudo unzip -o consul.zip -d /usr/local/bin
+sudo unzip -o consul.zip consul -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/consul
 sudo chown root:root /usr/local/bin/consul
 
@@ -57,7 +57,7 @@ sudo chmod 755 ${CONSULDIR}
 curl -sL -o nomad.zip ${NOMADDOWNLOAD}
 
 ## Install
-sudo unzip -o nomad.zip -d /usr/local/bin
+sudo unzip -o nomad.zip nomad -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/nomad
 sudo chown root:root /usr/local/bin/nomad
 

--- a/cloud/infrastructure/shared/packer/scripts/setup.sh
+++ b/cloud/infrastructure/shared/packer/scripts/setup.sh
@@ -68,10 +68,9 @@ sudo mkdir -p ${NOMADDIR}
 sudo chmod 755 ${NOMADDIR}
 
 # Docker
-distro=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
-sudo apt-get install -y apt-transport-https ca-certificates gnupg2 
-curl -fsSL https://download.docker.com/linux/debian/gpg | sudo APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/${distro} $(lsb_release -cs) stable"
+sudo apt-get install -y apt-transport-https ca-certificates gnupg2
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker.gpg
+echo "deb [signed-by=/usr/share/keyrings/docker.gpg arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
 sudo apt-get install -y docker-ce
 

--- a/cloud/shared/packer/scripts/client.sh
+++ b/cloud/shared/packer/scripts/client.sh
@@ -78,4 +78,4 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 # Set env vars for tool CLIs
 echo "export VAULT_ADDR=http://$IP_ADDRESS:8200" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc

--- a/cloud/shared/packer/scripts/client.sh
+++ b/cloud/shared/packer/scripts/client.sh
@@ -31,7 +31,7 @@ sudo cp $CONFIGDIR/consul_$CLOUD.service /etc/systemd/system/consul.service
 ## Replace existing Consul binary if remote file exists
 if [[ `wget -S --spider $CONSUL_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $CONSUL_BINARY > consul.zip
-  sudo unzip -o consul.zip -d /usr/local/bin
+  sudo unzip -o consul.zip consul -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/consul
   sudo chown root:root /usr/local/bin/consul
 fi
@@ -44,7 +44,7 @@ sleep 10
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $NOMAD_BINARY > nomad.zip
-  sudo unzip -o nomad.zip -d /usr/local/bin
+  sudo unzip -o nomad.zip nomad -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/nomad
   sudo chown root:root /usr/local/bin/nomad
 fi
@@ -78,4 +78,4 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 # Set env vars for tool CLIs
 echo "export VAULT_ADDR=http://$IP_ADDRESS:8200" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:/bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc

--- a/cloud/shared/packer/scripts/server.sh
+++ b/cloud/shared/packer/scripts/server.sh
@@ -26,7 +26,7 @@ RETRY_JOIN=$3
 ## Replace existing Consul binary if remote file exists
 if [[ `wget -S --spider $CONSUL_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $CONSUL_BINARY > consul.zip
-  sudo unzip -o consul.zip -d /usr/local/bin
+  sudo unzip -o consul.zip consul -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/consul
   sudo chown root:root /usr/local/bin/consul
 fi
@@ -47,7 +47,7 @@ export CONSUL_RPC_ADDR=$IP_ADDRESS:8400
 ## Replace existing Nomad binary if remote file exists
 if [[ `wget -S --spider $NOMAD_BINARY  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
   curl -L $NOMAD_BINARY > nomad.zip
-  sudo unzip -o nomad.zip -d /usr/local/bin
+  sudo unzip -o nomad.zip nomad -d /usr/local/bin
   sudo chmod 0755 /usr/local/bin/nomad
   sudo chown root:root /usr/local/bin/nomad
 fi
@@ -83,5 +83,5 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 echo "export CONSUL_RPC_ADDR=$IP_ADDRESS:8400" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:/bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
 

--- a/cloud/shared/packer/scripts/server.sh
+++ b/cloud/shared/packer/scripts/server.sh
@@ -83,5 +83,5 @@ sudo mv /etc/resolv.conf.new /etc/resolv.conf
 echo "export CONSUL_RPC_ADDR=$IP_ADDRESS:8400" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export CONSUL_HTTP_ADDR=$IP_ADDRESS:8500" | sudo tee --append /home/$HOME_DIR/.bashrc
 echo "export NOMAD_ADDR=http://$IP_ADDRESS:4646" | sudo tee --append /home/$HOME_DIR/.bashrc
-echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre"  | sudo tee --append /home/$HOME_DIR/.bashrc
+echo "export JAVA_HOME=$(readlink -f /usr/bin/java | sed 's:bin/java::')"  | sudo tee --append /home/$HOME_DIR/.bashrc
 

--- a/cloud/shared/packer/scripts/setup.sh
+++ b/cloud/shared/packer/scripts/setup.sh
@@ -43,7 +43,7 @@ sudo ufw disable || echo "ufw not installed"
 curl -sL -o consul.zip ${CONSULDOWNLOAD}
 
 ## Install
-sudo unzip -o consul.zip -d /usr/local/bin
+sudo unzip -o consul.zip consul -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/consul
 sudo chown root:root /usr/local/bin/consul
 
@@ -57,7 +57,7 @@ sudo chmod 755 ${CONSULDIR}
 curl -sL -o nomad.zip ${NOMADDOWNLOAD}
 
 ## Install
-sudo unzip -o nomad.zip -d /usr/local/bin
+sudo unzip -o nomad.zip nomad -d /usr/local/bin
 sudo chmod 0755 /usr/local/bin/nomad
 sudo chown root:root /usr/local/bin/nomad
 

--- a/cloud/shared/packer/scripts/setup.sh
+++ b/cloud/shared/packer/scripts/setup.sh
@@ -75,9 +75,7 @@ sudo apt-get update
 sudo apt-get install -y docker-ce
 
 # Java
-sudo add-apt-repository -y ppa:openjdk-r/ppa
-sudo apt-get update
-sudo apt-get install -y openjdk-8-jdk
+sudo apt-get install -y openjdk-11-jdk
 JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
 
 # CNI plugins

--- a/cloud/shared/packer/scripts/setup.sh
+++ b/cloud/shared/packer/scripts/setup.sh
@@ -68,10 +68,9 @@ sudo mkdir -p ${NOMADDIR}
 sudo chmod 755 ${NOMADDIR}
 
 # Docker
-distro=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
 sudo apt-get install -y apt-transport-https ca-certificates gnupg2
-curl -fsSL https://download.docker.com/linux/debian/gpg | sudo APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/${distro} $(lsb_release -cs) stable"
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker.gpg
+echo "deb [signed-by=/usr/share/keyrings/docker.gpg arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
 sudo apt-get install -y docker-ce
 


### PR DESCRIPTION
**Description:**  
[Ticket](https://hashicorp.atlassian.net/browse/NMD-1535?atlOrigin=eyJpIjoiZWM0NDViYjcwYzk3NDA1ODgxM2ZjZmNkMDM1M2UzNzgiLCJwIjoiaiJ9)

Fixes the Packer provisioner scripts (`setup.sh`, `client.sh`, `server.sh`) to work correctly on Ubuntu 22.04 (Jammy), following the base image updates in Part-1.

**Changes**

| File(s) | Change | Reason |
|---|---|---|
| `setup.sh` (both) | `unzip -o consul.zip` → `unzip -o consul.zip consul` (and nomad) | Ubuntu 22.04 `unzip` returns exit code 1 on warnings; with `set -e` this aborts the packer build |
| `setup.sh` (both) | Replace `apt-key add` + Debian GPG URL with `gpg --dearmor` keyring + Ubuntu GPG URL | `apt-key` is deprecated on 22.04; the old URL also incorrectly used the Debian repo for an Ubuntu host |
| `setup.sh` (both) | Replace `ppa:openjdk-r/ppa` + `openjdk-8-jdk` with `openjdk-11-jdk` | `openjdk-8-jdk` is not available in Ubuntu 22.04 repos; the PPA has no Jammy packages |
| `client.sh`, `server.sh` (both) | Same `unzip` fix for the binary override blocks | Same exit-code issue when `CONSUL_BINARY`/`NOMAD_BINARY` overrides are used |
| `client.sh`, `server.sh` (both) | Replace hardcoded `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre` with dynamic `readlink` | Path doesn't exist on 22.04; Java 11 has no separate `jre/` subdirectory |

Testing

- `packer validate` passes for all three cloud templates (AWS, GCP, Azure)
-  Vagrant DAS Demo (local, Apple Silicon / VirtualBox ARM64) `vagrant up` was run on macOS Apple Silicon (ARM64) with a Nomad Enterprise license.


<img width="1429" height="937" alt="Screenshot 2026-06-05 at 4 24 31 PM" src="https://github.com/user-attachments/assets/bbb9e229-8bab-4e22-9dfd-a8b2630e7208" />

<img width="1448" height="576" alt="Screenshot 2026-06-05 at 4 27 31 PM" src="https://github.com/user-attachments/assets/58acfccf-8d02-458c-8906-392c948eb91d" />

